### PR TITLE
Disable extended master secret extension with environment variable

### DIFF
--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -705,6 +705,11 @@ int tls_parse_extension(SSL *s, TLSEXT_INDEX idx, int context,
         /* We are handling a built-in extension */
         const EXTENSION_DEFINITION *extdef = &ext_defs[idx];
 
+        const char* disable_extms = getenv("DISABLE_EXTMS");
+        if (extdef->type == TLSEXT_TYPE_extended_master_secret && disable_extms != NULL && strcmp(disable_extms, "1") == 0) {
+            return 1;
+        }
+
         /* Check if extension is defined for our protocol. If not, skip */
         if (!extension_is_relevant(s, extdef->context, context))
             return 1;


### PR DESCRIPTION
The extended master secret extension can be disabled with DISABLE_EXTMS="1" 