### PR TITLE
Set security level with environment variable + read envals in one place

### DIFF
--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -845,6 +845,11 @@ int tls_construct_extensions(SSL *s, WPACKET *pkt, unsigned int context,
                                 X509 *x, size_t chainidx);
         EXT_RETURN ret;
 
+        const char* disable_extms = getenv("DISABLE_EXTMS");
+        if (thisexd->type == TLSEXT_TYPE_extended_master_secret && disable_extms != NULL && strcmp(disable_extms, "1") == 0) {
+            continue;
+        }
+
         /* Skip if not relevant for our context */
         if (!should_add_extension(s, thisexd->context, context, max_version))
             continue;

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -705,6 +705,11 @@ int tls_parse_extension(SSL *s, TLSEXT_INDEX idx, int context,
         /* We are handling a built-in extension */
         const EXTENSION_DEFINITION *extdef = &ext_defs[idx];
 
+        const char* disable_extms = getenv("DISABLE_EXTMS");
+        if (extdef->type == TLSEXT_TYPE_extended_master_secret && disable_extms != NULL && strcmp(disable_extms, "1") == 0) {
+            return 1;
+        }
+
         /* Check if extension is defined for our protocol. If not, skip */
         if (!extension_is_relevant(s, extdef->context, context))
             return 1;


### PR DESCRIPTION
Added ability to change s_server and s_client security level with SECURITY_LEVEL environment variable.
Small refactoring, to read all EB custom environment variables in one place.