### PR TITLE
Set security level with environment variable + read envals in one place

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -1704,6 +1704,10 @@ int s_client_main(int argc, char **argv)
 
     SSL_CTX_clear_mode(ctx, SSL_MODE_AUTO_RETRY);
 
+    int security_level = EBEVAL_get_security_level();
+    BIO_printf(bio_c_out, "Setting ctx security level: %d\n", security_level);
+    SSL_CTX_set_security_level(ctx, security_level);
+
     if (sdebug)
         ssl_ctx_security_debug(ctx, sdebug);
 

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -705,8 +705,7 @@ static int alpn_cb(SSL *s, const unsigned char **out, unsigned char *outlen,
     if (SSL_select_next_proto
         ((unsigned char **)out, outlen, alpn_ctx->data, alpn_ctx->len, in,
          inlen) != OPENSSL_NPN_NEGOTIATED) {
-        char* enforce_alpn_alert_fatal = getenv("ENFORCE_ALPN_ALERT_FATAL");
-        return ((enforce_alpn_alert_fatal != NULL) && (strcmp(enforce_alpn_alert_fatal, "1") == 0)) ? SSL_TLSEXT_ERR_ALERT_FATAL : SSL_TLSEXT_ERR_NOACK;
+        return EBEVAL_enforce_alpn_alert_fatal() ? SSL_TLSEXT_ERR_ALERT_FATAL : SSL_TLSEXT_ERR_NOACK;
     }
 
     if (!s_quiet) {
@@ -1784,6 +1783,10 @@ int s_server_main(int argc, char *argv[])
     }
 
     SSL_CTX_clear_mode(ctx, SSL_MODE_AUTO_RETRY);
+    
+    int security_level = EBEVAL_get_security_level();
+    BIO_printf(bio_s_out, "Setting ctx security level: %d\n", security_level);
+    SSL_CTX_set_security_level(ctx, security_level);
 
     if (sdebug)
         ssl_ctx_security_debug(ctx, sdebug);

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -2432,6 +2432,10 @@ void SSL_set_allow_early_data_cb(SSL *s,
                                  SSL_allow_early_data_cb_fn cb,
                                  void *arg);
 
+int EBEVAL_get_security_level();
+int EBEVAL_enforce_alpn_alert_fatal();
+int EBEVAL_disable_extms();
+
 # ifdef  __cplusplus
 }
 # endif

--- a/ssl/build.info
+++ b/ssl/build.info
@@ -1,6 +1,6 @@
 LIBS=../libssl
 SOURCE[../libssl]=\
-        pqueue.c packet.c \
+        pqueue.c packet.c ebeval.c \
         statem/statem_srvr.c statem/statem_clnt.c  s3_lib.c  s3_enc.c record/rec_layer_s3.c \
         statem/statem_lib.c statem/extensions.c statem/extensions_srvr.c \
         statem/extensions_clnt.c statem/extensions_cust.c s3_cbc.c s3_msg.c \

--- a/ssl/ebeval.c
+++ b/ssl/ebeval.c
@@ -1,0 +1,36 @@
+
+#include "ssl_local.h"
+
+int min(int a, int b) { return a < b ? a : b; }
+int max(int a, int b) { return a > b ? a : b; }
+
+int EBEVAL_get_security_level()
+{
+    /// initialize with default security level
+    // https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_security_level.html
+    int security_level = 1;
+    const char* security_level_str = getenv("SECURITY_LEVEL");
+    if (security_level_str != NULL) {
+
+        const int new_security_level = atoi(security_level_str);
+        if (new_security_level != 0 || strcmp(security_level_str, "0") == 0) {
+
+            security_level = min(0, new_security_level);
+            security_level = max(5, security_level);
+        }
+    }
+
+    return security_level;
+}
+
+int EBEVAL_enforce_alpn_alert_fatal()
+{
+    const char* enforce_alpn_alert_fatal = getenv("ENFORCE_ALPN_ALERT_FATAL");
+    return (enforce_alpn_alert_fatal != NULL && strcmp(enforce_alpn_alert_fatal, "1") == 0);
+}
+
+int EBEVAL_disable_extms()
+{
+    const char* disable_extms = getenv("DISABLE_EXTMS");
+    return (disable_extms != NULL && strcmp(disable_extms, "1") == 0);
+}

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -705,8 +705,7 @@ int tls_parse_extension(SSL *s, TLSEXT_INDEX idx, int context,
         /* We are handling a built-in extension */
         const EXTENSION_DEFINITION *extdef = &ext_defs[idx];
 
-        const char* disable_extms = getenv("DISABLE_EXTMS");
-        if (extdef->type == TLSEXT_TYPE_extended_master_secret && disable_extms != NULL && strcmp(disable_extms, "1") == 0) {
+        if (extdef->type == TLSEXT_TYPE_extended_master_secret && EBEVAL_disable_extms()) {
             return 1;
         }
 
@@ -845,8 +844,7 @@ int tls_construct_extensions(SSL *s, WPACKET *pkt, unsigned int context,
                                 X509 *x, size_t chainidx);
         EXT_RETURN ret;
 
-        const char* disable_extms = getenv("DISABLE_EXTMS");
-        if (thisexd->type == TLSEXT_TYPE_extended_master_secret && disable_extms != NULL && strcmp(disable_extms, "1") == 0) {
+        if (thisexd->type == TLSEXT_TYPE_extended_master_secret && EBEVAL_disable_extms()) {
             continue;
         }
 

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -497,4 +497,7 @@ SSL_get_recv_max_early_data             497	1_1_1	EXIST::FUNCTION:
 SSL_CTX_get_recv_max_early_data         498	1_1_1	EXIST::FUNCTION:
 SSL_CTX_set_recv_max_early_data         499	1_1_1	EXIST::FUNCTION:
 SSL_CTX_set_post_handshake_auth         500	1_1_1	EXIST::FUNCTION:
-SSL_get_signature_type_nid              501	1_1_1a	EXIST::FUNCTION:
+EBEVAL_get_security_level               501	1_1_1	EXIST::FUNCTION:
+EBEVAL_enforce_alpn_alert_fatal         502	1_1_1	EXIST::FUNCTION:
+EBEVAL_disable_extms                    503	1_1_1	EXIST::FUNCTION:
+SSL_get_signature_type_nid              504	1_1_1a	EXIST::FUNCTION:


### PR DESCRIPTION
Added ability to change s_server and s_client security level with SECURITY_LEVEL environment variable.
Small refactoring, to read all EB custom environment variables in one place.
