### PR TITLE
Enable compression for DTLS + disable NULL compression

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -2435,6 +2435,8 @@ void SSL_set_allow_early_data_cb(SSL *s,
 int EBEVAL_get_security_level();
 int EBEVAL_enforce_alpn_alert_fatal();
 int EBEVAL_disable_extms();
+int EBEVAL_enable_dtls_comp();
+int EBEVAL_disable_null_comp();
 
 # ifdef  __cplusplus
 }

--- a/ssl/ebeval.c
+++ b/ssl/ebeval.c
@@ -1,8 +1,17 @@
 
 #include "ssl_local.h"
 
-int min(int a, int b) { return a < b ? a : b; }
-int max(int a, int b) { return a > b ? a : b; }
+static int min(int a, int b) { return a < b ? a : b; }
+static int max(int a, int b) { return a > b ? a : b; }
+
+static int is_eval_set(const char* eval)
+{   
+    if (eval != NULL) {
+        const char* eval_value = getenv(eval);
+        return (eval_value != NULL && strcmp(eval_value, "1") == 0);
+    }
+    return 0;
+}
 
 int EBEVAL_get_security_level()
 {
@@ -25,12 +34,20 @@ int EBEVAL_get_security_level()
 
 int EBEVAL_enforce_alpn_alert_fatal()
 {
-    const char* enforce_alpn_alert_fatal = getenv("ENFORCE_ALPN_ALERT_FATAL");
-    return (enforce_alpn_alert_fatal != NULL && strcmp(enforce_alpn_alert_fatal, "1") == 0);
+    return is_eval_set("ENFORCE_ALPN_ALERT_FATAL");
 }
 
 int EBEVAL_disable_extms()
 {
-    const char* disable_extms = getenv("DISABLE_EXTMS");
-    return (disable_extms != NULL && strcmp(disable_extms, "1") == 0);
+    return is_eval_set("DISABLE_EXTMS");
+}
+
+int EBEVAL_enable_dtls_comp()
+{
+    return is_eval_set("ENABLE_DTLS_COMP");
+}
+
+int EBEVAL_disable_null_comp()
+{
+    return is_eval_set("DISABLE_NULL_COMP");
 }

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3048,7 +3048,7 @@ SSL_CTX *SSL_CTX_new(const SSL_METHOD *meth)
         goto err;
 
     /* No compression for DTLS */
-    if (!(meth->ssl3_enc->enc_flags & SSL_ENC_FLAG_DTLS))
+    if (EBEVAL_enable_dtls_comp() || !(meth->ssl3_enc->enc_flags & SSL_ENC_FLAG_DTLS))
         ret->comp_methods = SSL_COMP_get_compression_methods();
 
     ret->max_send_fragment = SSL3_RT_MAX_PLAIN_LENGTH;

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3048,7 +3048,7 @@ SSL_CTX *SSL_CTX_new(const SSL_METHOD *meth)
         goto err;
 
     /* No compression for DTLS */
-    if (EBEVAL_enable_dtls_comp() || !(meth->ssl3_enc->enc_flags & SSL_ENC_FLAG_DTLS))
+    if (!(meth->ssl3_enc->enc_flags & SSL_ENC_FLAG_DTLS) || EBEVAL_enable_dtls_comp())
         ret->comp_methods = SSL_COMP_get_compression_methods();
 
     ret->max_send_fragment = SSL3_RT_MAX_PLAIN_LENGTH;

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -1277,7 +1277,7 @@ int tls_construct_client_hello(SSL *s, WPACKET *pkt)
     }
 #endif
     /* Add the NULL method */
-    if (!WPACKET_put_bytes_u8(pkt, 0) || !WPACKET_close(pkt)) {
+    if (!(EBEVAL_disable_null_comp() || WPACKET_put_bytes_u8(pkt, 0)) || !WPACKET_close(pkt)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_CONSTRUCT_CLIENT_HELLO,
                  ERR_R_INTERNAL_ERROR);
         return 0;

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -500,4 +500,6 @@ SSL_CTX_set_post_handshake_auth         500	1_1_1	EXIST::FUNCTION:
 EBEVAL_get_security_level               501	1_1_1	EXIST::FUNCTION:
 EBEVAL_enforce_alpn_alert_fatal         502	1_1_1	EXIST::FUNCTION:
 EBEVAL_disable_extms                    503	1_1_1	EXIST::FUNCTION:
-SSL_get_signature_type_nid              504	1_1_1a	EXIST::FUNCTION:
+EBEVAL_enable_dtls_comp                 504	1_1_1	EXIST::FUNCTION:
+EBEVAL_disable_null_comp                505	1_1_1	EXIST::FUNCTION:
+SSL_get_signature_type_nid              506	1_1_1a	EXIST::FUNCTION:


### PR DESCRIPTION
This pull request introduces ability to enable additional compression method for DTLS (DEFLATE method) + ability to remove NULL compression method for TLS & DTLS (client only) by setting up following environment variable:

- ENABLE_DTLS_COMP="1"
- DISABLE_NULL_COMP="1"

**Note:** 

- following configuration parameter needs to be added while executing Configure or config script before compilation:
**enable-comp enable-zlib**
- option **-comp** have to be added when executing s_client application to add additional compression method (DEFLATE) to Client_Hello message
